### PR TITLE
fix: controlnet not enabled

### DIFF
--- a/signerf/diffuser/diffuser.py
+++ b/signerf/diffuser/diffuser.py
@@ -146,6 +146,7 @@ class Diffuser:
                 "controlnet": {
                     "args": [
                         {
+                            "enabled": True,
                             "input_image": condition_image_bytes,
                             "model": self.controlnet_model,
                             "module": "none",


### PR DESCRIPTION
I found that if I don't add this line in the HTTP request, ControlNet will not affect the reference sheet, resulting in an outcome similar to the one described in https://github.com/cgtuebingen/SIGNeRF/issues/9. After adding this line, the result will match the one shown on the project page.